### PR TITLE
Added update/create syncing support to beta testers and groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/alessio/shellescape v1.2.2
 	github.com/apex/log v1.9.0
-	github.com/cidertool/asc-go v0.3.6
+	github.com/cidertool/asc-go v0.3.7
 	github.com/fatih/color v1.9.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/manifoldco/promptui v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cidertool/asc-go v0.3.6 h1:KVve7Bi4/2pLNj3hGPZZcmlnm3fYFNZvUwzvr4ulWiY=
-github.com/cidertool/asc-go v0.3.6/go.mod h1:KwOKlc2MwulaVFejJJSJkVKuIWX5HdedcbdX/QzeeFE=
+github.com/cidertool/asc-go v0.3.7 h1:e88Eqy0z1Hq0MgwBPPUfSgMchAupMRU1TKgLYWDZG30=
+github.com/cidertool/asc-go v0.3.7/go.mod h1:KwOKlc2MwulaVFejJJSJkVKuIWX5HdedcbdX/QzeeFE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cidertool/asc-go v0.3.5 h1:FGkuh6K0q3DovUYqoYcQz3LkKpUoONbgd7SQH+LeR/4=
-github.com/cidertool/asc-go v0.3.5/go.mod h1:KwOKlc2MwulaVFejJJSJkVKuIWX5HdedcbdX/QzeeFE=
 github.com/cidertool/asc-go v0.3.6 h1:KVve7Bi4/2pLNj3hGPZZcmlnm3fYFNZvUwzvr4ulWiY=
 github.com/cidertool/asc-go v0.3.6/go.mod h1:KwOKlc2MwulaVFejJJSJkVKuIWX5HdedcbdX/QzeeFE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	// UpdateBetaLicenseAgreement updates an App's beta license agreement, or creates a new one if one does not yet exist.
 	UpdateBetaLicenseAgreement(ctx *context.Context, appID string, config config.Testflight) error
 	AssignBetaGroups(ctx *context.Context, appID string, buildID string, groups []config.BetaGroup) error
-	AssignBetaTesters(ctx *context.Context, appID string, buildID string, betaGroupID string, testers []config.BetaTester) error
+	AssignBetaTesters(ctx *context.Context, appID string, buildID string, testers []config.BetaTester) error
 	// UpdateBetaReviewDetails updates an App's beta review details, or creates new ones if they do not yet exist.
 	UpdateBetaReviewDetails(ctx *context.Context, appID string, config config.ReviewDetails) error
 	// SubmitBetaApp submits the given beta build for review

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	// UpdateBetaLicenseAgreement updates an App's beta license agreement, or creates a new one if one does not yet exist.
 	UpdateBetaLicenseAgreement(ctx *context.Context, appID string, config config.Testflight) error
 	AssignBetaGroups(ctx *context.Context, appID string, buildID string, groups []config.BetaGroup) error
-	AssignBetaTesters(ctx *context.Context, appID string, buildID string, testers []config.BetaTester) error
+	AssignBetaTesters(ctx *context.Context, appID string, buildID string, betaGroupID string, testers []config.BetaTester) error
 	// UpdateBetaReviewDetails updates an App's beta review details, or creates new ones if they do not yet exist.
 	UpdateBetaReviewDetails(ctx *context.Context, appID string, config config.ReviewDetails) error
 	// SubmitBetaApp submits the given beta build for review

--- a/internal/client/testflight.go
+++ b/internal/client/testflight.go
@@ -211,7 +211,6 @@ func (c *ascClient) AssignBetaTesters(ctx *context.Context, appID string, buildI
 	var g = parallel.New(ctx.MaxProcesses)
 
 	if len(testers) == 0 {
-		log.Debug("no testers provided as input to add")
 		return nil
 	}
 
@@ -261,9 +260,6 @@ func (c *ascClient) AssignBetaTesters(ctx *context.Context, appID string, buildI
 }
 
 func (c *ascClient) listBetaTesters(ctx *context.Context, appID string, config []config.BetaTester) ([]asc.BetaTester, error) {
-	if len(config) == 0 {
-		return nil, nil
-	}
 	emailFilters := make([]string, 0)
 	firstNameFilters := make([]string, 0)
 	lastNameFilters := make([]string, 0)

--- a/internal/client/testflight_test.go
+++ b/internal/client/testflight_test.go
@@ -366,6 +366,9 @@ func TestAssignBetaGroups_Happy(t *testing.T) {
 		response{
 			RawResponse: `{}`,
 		},
+		response{
+			RawResponse: `{}`,
+		},
 	)
 	defer ctx.Close()
 
@@ -412,9 +415,12 @@ func TestAssignBetaGroups_WarnNoTestersMatching(t *testing.T) {
 func TestAssignBetaGroups_ErrAssign(t *testing.T) {
 	ctx, client := newTestContext(
 		response{
-			Response: asc.BetaTestersResponse{
-				Data: []asc.BetaTester{
-					{ID: testID},
+			Response: asc.BetaGroupsResponse{
+				Data: []asc.BetaGroup{
+					{
+						ID:         testID,
+						Attributes: &asc.BetaGroupAttributes{Name: asc.String(testID)},
+					},
 				},
 			},
 		},
@@ -447,10 +453,13 @@ func TestAssignBetaTesters_Happy(t *testing.T) {
 		response{
 			RawResponse: `{}`,
 		},
+		response{
+			RawResponse: `{}`,
+		},
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{
 		{
 			Email:     "test@email.com",
 			FirstName: "John",
@@ -474,7 +483,7 @@ func TestAssignBetaTesters_WarnNoTestersInput(t *testing.T) {
 	ctx, client := newTestContext()
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{})
 	assert.NoError(t, err)
 }
 
@@ -487,7 +496,7 @@ func TestAssignBetaTesters_ErrList(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{{}})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{{}})
 	assert.Error(t, err)
 }
 
@@ -499,16 +508,22 @@ func TestAssignBetaTesters_WarnNoTestersMatching(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{{}})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{{}})
 	assert.NoError(t, err)
 }
 
 func TestAssignBetaTesters_ErrAssign(t *testing.T) {
+	testEmail := asc.Email("test@email.com")
 	ctx, client := newTestContext(
 		response{
 			Response: asc.BetaTestersResponse{
 				Data: []asc.BetaTester{
-					{ID: testID},
+					{
+						ID: testID,
+						Attributes: &asc.BetaTesterAttributes{
+							Email: &testEmail,
+						},
+					},
 				},
 			},
 		},
@@ -519,7 +534,7 @@ func TestAssignBetaTesters_ErrAssign(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{{}})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{{}})
 	assert.Error(t, err)
 }
 

--- a/internal/client/testflight_test.go
+++ b/internal/client/testflight_test.go
@@ -395,6 +395,9 @@ func TestAssignBetaGroups_Happy(t *testing.T) {
 		response{
 			RawResponse: `{}`,
 		},
+		response{
+			RawResponse: `{}`,
+		},
 	)
 	defer ctx.Close()
 
@@ -482,7 +485,9 @@ func TestAssignBetaGroups_ErrAssign(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaGroups(ctx.Context, testID, testID, []config.BetaGroup{{}})
+	err := client.AssignBetaGroups(ctx.Context, testID, testID, []config.BetaGroup{
+		{Name: testID},
+	})
 	assert.Error(t, err)
 }
 
@@ -528,7 +533,7 @@ func TestAssignBetaTesters_Happy(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{
 		{
 			Email:     "test@email.com",
 			FirstName: "John",
@@ -552,7 +557,7 @@ func TestAssignBetaTesters_WarnNoTestersInput(t *testing.T) {
 	ctx, client := newTestContext()
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{})
 	assert.NoError(t, err)
 }
 
@@ -565,7 +570,7 @@ func TestAssignBetaTesters_ErrList(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{{}})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{{}})
 	assert.Error(t, err)
 }
 
@@ -577,7 +582,7 @@ func TestAssignBetaTesters_WarnNoTestersMatching(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{{}})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{{}})
 	assert.NoError(t, err)
 }
 
@@ -603,7 +608,7 @@ func TestAssignBetaTesters_ErrAssign(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	err := client.AssignBetaTesters(ctx.Context, testID, testID, "", []config.BetaTester{{}})
+	err := client.AssignBetaTesters(ctx.Context, testID, testID, []config.BetaTester{{}})
 	assert.Error(t, err)
 }
 

--- a/internal/client/util_test.go
+++ b/internal/client/util_test.go
@@ -59,6 +59,7 @@ func (c *testContext) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.WithFields(log.Fields{
 			"currentResponseIndex": c.CurrentResponseIndex,
 			"responsesCount":       len(c.Responses),
+			"route":                r.URL.Path,
 		}).Fatal("index out of bounds")
 	}
 

--- a/internal/defaults/defaults_test.go
+++ b/internal/defaults/defaults_test.go
@@ -1,0 +1,3 @@
+package defaults
+
+// this package has no testable statements

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -64,13 +64,23 @@ func TestSanitizeProcess(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestExtractRemoteFromConfig(t *testing.T) {
+func TestShowRef(t *testing.T) {
+	// Selected the initial commit of this repo, because I needed a sha1 hash.
+	expected := "eac16d260ebf8af83873c9704169cf40a5501f84"
+	client := newMockGit(
+		command{Stdout: expected},
+	)
+	got, err := client.Show("%H")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestExtractRemoteFromConfig_Happy(t *testing.T) {
 	expected := config.Repo{
 		Name:  "cider",
 		Owner: "cidertool",
 	}
 
-	// happy path
 	client := newMockGit(
 		command{Stdout: "true"},
 		command{Stdout: "git@github.com:cidertool/cider.git"},
@@ -78,19 +88,23 @@ func TestExtractRemoteFromConfig(t *testing.T) {
 	repo, err := client.ExtractRepoFromConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, expected, repo)
+}
 
-	client = newMockGit(
+func TestExtractRemoteFromConfig_ErrIsNotRepo(t *testing.T) {
+	client := newMockGit(
 		command{Stdout: "false"},
 	)
-	repo, err = client.ExtractRepoFromConfig()
+	repo, err := client.ExtractRepoFromConfig()
 	assert.Error(t, err)
 	assert.Empty(t, repo)
+}
 
-	client = newMockGit(
+func TestExtractRemoteFromConfig_ErrNoRemoteNamedOrigin(t *testing.T) {
+	client := newMockGit(
 		command{Stdout: "true"},
 		command{ReturnCode: 1, Stderr: "no repo"},
 	)
-	repo, err = client.ExtractRepoFromConfig()
+	repo, err := client.ExtractRepoFromConfig()
 	assert.Error(t, err)
 	assert.Empty(t, repo)
 }

--- a/internal/middleware/error_test.go
+++ b/internal/middleware/error_test.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cidertool/cider/internal/pipe"
+	"github.com/cidertool/cider/pkg/config"
+	"github.com/cidertool/cider/pkg/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrHandler_WrapsError(t *testing.T) {
+	ctx := context.New(config.Project{})
+	wrapped := ErrHandler(func(ctx *context.Context) error {
+		return errors.New("TEST")
+	})
+	err := wrapped(ctx)
+	assert.Error(t, err)
+}
+
+func TestErrHandler_IgnoresNoError(t *testing.T) {
+	ctx := context.New(config.Project{})
+	wrapped := ErrHandler(func(ctx *context.Context) error {
+		return nil
+	})
+	err := wrapped(ctx)
+	assert.NoError(t, err)
+}
+
+func TestErrHandler_HandlesSkip(t *testing.T) {
+	ctx := context.New(config.Project{})
+	wrapped := ErrHandler(func(ctx *context.Context) error {
+		return pipe.Skip("TEST")
+	})
+	err := wrapped(ctx)
+	assert.NoError(t, err)
+}

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/cidertool/cider/pkg/config"
+	"github.com/cidertool/cider/pkg/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogging(t *testing.T) {
+	ctx := context.New(config.Project{})
+	wrapped := Logging("TEST", func(ctx *context.Context) error {
+		return nil
+	}, DefaultInitialPadding)
+	err := wrapped(ctx)
+	assert.NoError(t, err)
+}

--- a/internal/parallel/group.go
+++ b/internal/parallel/group.go
@@ -16,7 +16,7 @@ type Group interface {
 
 // New returns a new Group of a given size.
 func New(size int) Group {
-	if size == 1 {
+	if size <= 1 {
 		return &serialGroup{}
 	}
 	return &parallelGroup{

--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -8,15 +8,20 @@ import (
 )
 
 // Pipe that sets the defaults.
-type Pipe struct{}
+type Pipe struct {
+	defaulters []defaults.Defaulter
+}
 
 func (Pipe) String() string {
 	return "setting defaults"
 }
 
 // Run the pipe.
-func (Pipe) Run(ctx *context.Context) error {
-	for _, defaulter := range defaults.Defaulters {
+func (p Pipe) Run(ctx *context.Context) error {
+	if len(p.defaulters) == 0 {
+		p.defaulters = defaults.Defaulters
+	}
+	for _, defaulter := range p.defaulters {
 		if err := middleware.Logging(
 			defaulter.String(),
 			middleware.ErrHandler(defaulter.Default),

--- a/internal/pipe/defaults/defaults_test.go
+++ b/internal/pipe/defaults/defaults_test.go
@@ -1,0 +1,38 @@
+package defaults
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cidertool/cider/internal/defaults"
+	"github.com/cidertool/cider/pkg/config"
+	"github.com/cidertool/cider/pkg/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaults(t *testing.T) {
+	ctx := context.New(config.Project{})
+	pipe := Pipe{}
+	var err error
+
+	assert.Equal(t, "setting defaults", pipe.String())
+
+	err = pipe.Run(ctx)
+	assert.NoError(t, err)
+
+	pipe.defaulters = []defaults.Defaulter{
+		mockDefaulter{},
+	}
+	err = pipe.Run(ctx)
+	assert.Error(t, err)
+}
+
+type mockDefaulter struct{}
+
+func (d mockDefaulter) String() string {
+	return ""
+}
+
+func (d mockDefaulter) Default(ctx *context.Context) error {
+	return errors.New("TEST")
+}

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -18,7 +18,9 @@ import (
 const NoTag = "v0.0.0"
 
 // Pipe is a global hook pipe.
-type Pipe struct{}
+type Pipe struct {
+	client *git.Git
+}
 
 // String is the name of this pipe.
 func (Pipe) String() string {
@@ -37,7 +39,10 @@ func (p Pipe) Run(ctx *context.Context) error {
 		return pipe.ErrSkipGitEnabled
 	}
 
-	client := git.New(ctx)
+	client := p.client
+	if client == nil {
+		client = git.New(ctx)
+	}
 
 	if ok := client.Exists("git"); !ok {
 		return git.ErrNoGit

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -1,0 +1,3 @@
+package git
+
+// WIP

--- a/internal/pipe/pipe_test.go
+++ b/internal/pipe/pipe_test.go
@@ -1,0 +1,17 @@
+package pipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipeSkip(t *testing.T) {
+	skip := Skip("TEST")
+	var err error = ErrSkip{reason: "TEST"}
+	assert.Error(t, skip)
+	assert.Error(t, err)
+	assert.True(t, IsSkip(err))
+	assert.Equal(t, err, skip)
+	assert.Equal(t, err.Error(), skip.Error())
+}

--- a/internal/pipe/publish/publish_test.go
+++ b/internal/pipe/publish/publish_test.go
@@ -1,0 +1,3 @@
+package publish
+
+// WIP

--- a/internal/pipe/store/store.go
+++ b/internal/pipe/store/store.go
@@ -20,9 +20,6 @@ func (Pipe) String() string {
 
 // Publish to App Store Review.
 func (p Pipe) Publish(ctx *context.Context) error {
-	if ctx.PublishMode != context.PublishModeAppStore {
-		return pipe.Skip("app store")
-	}
 	client := client.New(ctx)
 	for _, name := range ctx.AppsToRelease {
 		app := ctx.Config[name]

--- a/internal/pipe/testflight/testflight.go
+++ b/internal/pipe/testflight/testflight.go
@@ -22,9 +22,6 @@ func (Pipe) String() string {
 
 // Publish to Testflight.
 func (p Pipe) Publish(ctx *context.Context) error {
-	if ctx.PublishMode != context.PublishModeTestflight {
-		return pipe.Skip("testflight")
-	}
 	client := client.New(ctx)
 	for _, name := range ctx.AppsToRelease {
 		app := ctx.Config[name]

--- a/internal/pipe/testflight/testflight.go
+++ b/internal/pipe/testflight/testflight.go
@@ -92,7 +92,7 @@ func updateBetaDetails(ctx *context.Context, config config.App, client client.Cl
 		return err
 	}
 	log.Info("updating build beta testers")
-	if err := client.AssignBetaTesters(ctx, app.ID, build.ID, "", config.Testflight.BetaTesters); err != nil {
+	if err := client.AssignBetaTesters(ctx, app.ID, build.ID, config.Testflight.BetaTesters); err != nil {
 		return err
 	}
 	if config.Testflight.ReviewDetails != nil {

--- a/internal/pipe/testflight/testflight.go
+++ b/internal/pipe/testflight/testflight.go
@@ -95,7 +95,7 @@ func updateBetaDetails(ctx *context.Context, config config.App, client client.Cl
 		return err
 	}
 	log.Info("updating build beta testers")
-	if err := client.AssignBetaTesters(ctx, app.ID, build.ID, config.Testflight.BetaTesters); err != nil {
+	if err := client.AssignBetaTesters(ctx, app.ID, build.ID, "", config.Testflight.BetaTesters); err != nil {
 		return err
 	}
 	if config.Testflight.ReviewDetails != nil {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,3 @@
+package pipeline
+
+// this package has no testable statements


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds support for syncing beta groups and testers, so that configuration can be shared between apps easily. This represents an overhaul of how beta groups and testers are managed by Cider. 

Fixes #33 

## Type of Change


- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How has this been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

I wrote many new unit tests, and tested rigorously against a private app I use for testing.  