### PR TITLE
Remove data races by avoiding global CLI logger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run gendoc tool
         run: go run ./tools/gendoc
-      
+
       - name: Run licensing tool
         run: go run ./tools/licensing
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,13 +39,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run Tests
-        run: go test -race -coverprofile coverage.out -covermode atomic -json ./... > cider.testresults
-
-      - name: Annotate Test Results
-        if: always()
-        uses: guyarb/golang-test-annoations@v0.4.0
-        with:
-          test-results: cider.testresults
+        run: go test -race -coverprofile coverage.out -covermode atomic ./...
 
       - name: Upload Coverage to Codecov
         if: success()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run Tests
-        run: go test -v -race -coverprofile coverage.out -covermode atomic -json ./... > cider.testresults
+        run: go test -race -coverprofile coverage.out -covermode atomic -json ./... > cider.testresults
 
       - name: Annotate Test Results
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@master
         with:
-          version: v1.37
+          version: v1.39
           skip-go-installation: true
 
   verify_doc_tools:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,13 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run Tests
-        run: go test -v -race -coverprofile coverage.out -covermode atomic ./...
+        run: go test -v -race -coverprofile coverage.out -covermode atomic -json ./... > cider.testresults
+
+      - name: Annotate Test Results
+        if: always()
+        uses: guyarb/golang-test-annoations@v0.4.0
+        with:
+          test-results: cider.testresults
 
       - name: Upload Coverage to Codecov
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,6 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Test results JSON
-*.testresults
-
 # Output of the go coverage tool
 *.out
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,10 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Test results JSON
+*.testresults
+
+# Output of the go coverage tool
 *.out
 
 # Dependency directories (remove the comment below to include it)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Documentation is hosted at <https://cidertool.github.io/cider>. Check out our in
 
 ## Integrations
 
--   [GitHub Action](https://github.com/marketplace/actions/cider-action)
--   [Buildkite Plugin](https://github.com/cidertool/cider-buildkite-plugin)
+- [GitHub Action](https://github.com/marketplace/actions/cider-action)
+- [Buildkite Plugin](https://github.com/cidertool/cider-buildkite-plugin)
 
 ## Badges
 
@@ -37,7 +37,7 @@ This project's primary goal is to simplify the process to release on the App Sto
 
 Special thanks to:
 
--   [GoReleaser](https://goreleaser.com/) for inspiring the architecture and open sourcing several components used in Cider
+- [GoReleaser](https://goreleaser.com/) for inspiring the architecture and open sourcing several components used in Cider
 
 ## License
 

--- a/internal/clicommand/check_test.go
+++ b/internal/clicommand/check_test.go
@@ -32,7 +32,9 @@ import (
 func TestCheckCmd(t *testing.T) {
 	t.Parallel()
 
-	var cmd = newCheckCmd()
+	var noDebug bool
+
+	var cmd = newCheckCmd(&noDebug)
 
 	var path = filepath.Join(t.TempDir(), "foo.yaml")
 

--- a/internal/clicommand/clicommand.go
+++ b/internal/clicommand/clicommand.go
@@ -18,10 +18,10 @@ You should have received a copy of the GNU General Public License
 along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Package clicommand declares the command line interface for Cider.
 package clicommand
 
 import (
-	"flag"
 	"os"
 
 	"github.com/cidertool/cider/internal/log"
@@ -30,13 +30,13 @@ import (
 func newLogger(debugFlagValue *bool) *log.Log {
 	logger := log.New()
 
+	if os.Getenv("CI") != "" {
+		logger.SetColorMode(false)
+	}
+
 	if debugFlagValue != nil {
 		logger.SetDebug(*debugFlagValue)
 		logger.Debug("debug logs enabled")
-	}
-
-	if os.Getenv("CI") != "" && flag.Lookup("test.v") == nil {
-		logger.SetColorMode(false)
 	}
 
 	return logger

--- a/internal/clicommand/clicommand.go
+++ b/internal/clicommand/clicommand.go
@@ -21,6 +21,7 @@ along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 package clicommand
 
 import (
+	"flag"
 	"os"
 
 	"github.com/cidertool/cider/internal/log"
@@ -29,13 +30,13 @@ import (
 func newLogger(debugFlagValue *bool) *log.Log {
 	logger := log.New()
 
-	if os.Getenv("CI") != "" {
-		logger.SetColorMode(false)
-	}
-
 	if debugFlagValue != nil {
 		logger.SetDebug(*debugFlagValue)
 		logger.Debug("debug logs enabled")
+	}
+
+	if os.Getenv("CI") != "" && flag.Lookup("test.v") == nil {
+		logger.SetColorMode(false)
 	}
 
 	return logger

--- a/internal/clicommand/clicommand.go
+++ b/internal/clicommand/clicommand.go
@@ -22,17 +22,16 @@ along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 package clicommand
 
 import (
-	"os"
-
 	"github.com/cidertool/cider/internal/log"
 )
 
 func newLogger(debugFlagValue *bool) *log.Log {
 	logger := log.New()
 
-	if os.Getenv("CI") != "" {
-		logger.SetColorMode(false)
-	}
+	// Comment this out as it's causing issues during parallel testing
+	// if os.Getenv("CI") != "" {
+	// 	logger.SetColorMode(false)
+	// }
 
 	if debugFlagValue != nil {
 		logger.SetDebug(*debugFlagValue)

--- a/internal/clicommand/clicommand.go
+++ b/internal/clicommand/clicommand.go
@@ -18,28 +18,25 @@ You should have received a copy of the GNU General Public License
 along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package middleware
+package clicommand
 
 import (
-	"github.com/cidertool/cider/internal/pipe"
-	"github.com/cidertool/cider/pkg/context"
+	"os"
+
+	"github.com/cidertool/cider/internal/log"
 )
 
-// ErrHandler handles an action error, ignoring and logging pipe skipped
-// errors.
-func ErrHandler(action Action) Action {
-	return func(ctx *context.Context) error {
-		var err = action(ctx)
-		if err == nil {
-			return nil
-		}
+func newLogger(debugFlagValue *bool) *log.Log {
+	logger := log.New()
 
-		if pipe.IsSkip(err) {
-			ctx.Log.WithError(err).Warn("pipe skipped")
-
-			return nil
-		}
-
-		return err
+	if os.Getenv("CI") != "" {
+		logger.SetColorMode(false)
 	}
+
+	if debugFlagValue != nil {
+		logger.SetDebug(*debugFlagValue)
+		logger.Debug("debug logs enabled")
+	}
+
+	return logger
 }

--- a/internal/clicommand/init.go
+++ b/internal/clicommand/init.go
@@ -41,9 +41,8 @@ const configDocString = `# This is a template .cider.yaml file with some sane de
 `
 
 type initCmd struct {
-	cmd            *cobra.Command
-	debugFlagValue *bool
-	opts           initOpts
+	cmd  *cobra.Command
+	opts initOpts
 }
 
 type initOpts struct {

--- a/internal/clicommand/init_test.go
+++ b/internal/clicommand/init_test.go
@@ -32,7 +32,9 @@ func TestInitCmd(t *testing.T) {
 
 	var folder = t.TempDir()
 
-	var cmd = newInitCmd().cmd
+	var noDebug bool
+
+	var cmd = newInitCmd(&noDebug).cmd
 
 	var path = filepath.Join(folder, "foo.yaml")
 

--- a/internal/clicommand/root.go
+++ b/internal/clicommand/root.go
@@ -18,7 +18,6 @@ You should have received a copy of the GNU General Public License
 along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// Package clicommand declares the command line interface for Cider.
 package clicommand
 
 import (

--- a/internal/clicommand/root.go
+++ b/internal/clicommand/root.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 
 	"github.com/apex/log"
-	"github.com/apex/log/handlers/cli"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -116,13 +114,13 @@ func (cmd *Root) customizeLogger(c *cobra.Command, args []string) {
 	defer loggerMu.Unlock()
 
 	if os.Getenv("CI") != "" {
-		color.NoColor = false
+		// color.NoColor = false
 	}
 
-	log.SetHandler(cli.Default)
+	// log.SetHandler(cli.Default)
 
 	if cmd.debug {
-		log.SetLevel(log.DebugLevel)
+		// log.SetLevel(log.DebugLevel)
 		log.Debug("debug logs enabled")
 	}
 }

--- a/internal/clicommand/root.go
+++ b/internal/clicommand/root.go
@@ -121,7 +121,7 @@ func (cmd *Root) customizeLogger(c *cobra.Command, args []string) {
 	// log.SetHandler(cli.Default)
 
 	if cmd.debug {
-		// log.SetLevel(log.DebugLevel)
+		log.SetLevel(log.DebugLevel)
 		log.Debug("debug logs enabled")
 	}
 }

--- a/internal/clicommand/root.go
+++ b/internal/clicommand/root.go
@@ -121,7 +121,7 @@ func (cmd *Root) customizeLogger(c *cobra.Command, args []string) {
 	// log.SetHandler(cli.Default)
 
 	if cmd.debug {
-		log.SetLevel(log.DebugLevel)
+		// log.SetLevel(log.DebugLevel)
 		log.Debug("debug logs enabled")
 	}
 }

--- a/internal/clicommand/root.go
+++ b/internal/clicommand/root.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 
 	"github.com/apex/log"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -114,7 +115,7 @@ func (cmd *Root) customizeLogger(c *cobra.Command, args []string) {
 	defer loggerMu.Unlock()
 
 	if os.Getenv("CI") != "" {
-		// color.NoColor = false
+		color.NoColor = false
 	}
 
 	// log.SetHandler(cli.Default)

--- a/internal/clicommand/root_test.go
+++ b/internal/clicommand/root_test.go
@@ -21,7 +21,6 @@ along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 package clicommand
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,8 +32,7 @@ func TestRootCmd(t *testing.T) {
 	exit := func(code int) {
 		assert.Equal(t, 0, code)
 	}
-	err := os.Setenv("CI", "1")
-	assert.NoError(t, err)
+
 	Execute("TEST", exit, []string{"help", "--debug"})
 }
 
@@ -44,5 +42,6 @@ func TestRootCmd_Error(t *testing.T) {
 	exit := func(code int) {
 		assert.NotEqual(t, 0, code)
 	}
+
 	Execute("TEST", exit, []string{"check"})
 }

--- a/internal/client/assets.go
+++ b/internal/client/assets.go
@@ -28,9 +28,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/apex/log"
 	"github.com/cidertool/asc-go/asc"
 	"github.com/cidertool/cider/internal/closer"
+	"github.com/cidertool/cider/internal/log"
 	"github.com/cidertool/cider/internal/parallel"
 	"github.com/cidertool/cider/pkg/config"
 	"github.com/cidertool/cider/pkg/context"
@@ -74,7 +74,7 @@ func (c *ascClient) UploadRoutingCoverage(ctx *context.Context, versionID string
 	prepare := func(name string, checksum string) (shouldContinue bool, err error) {
 		covResp, _, err := c.client.Apps.GetRoutingAppCoverageForAppStoreVersion(ctx, versionID, nil)
 		if err != nil {
-			log.Warn(err.Error())
+			ctx.Log.Warn(err.Error())
 		}
 
 		if covResp == nil {
@@ -165,7 +165,7 @@ func (c *ascClient) UploadPreviews(ctx *context.Context, g parallel.Group, previ
 
 		if preview.Attributes.SourceFileChecksum != nil &&
 			*preview.Attributes.SourceFileChecksum == checksum {
-			log.WithFields(log.Fields{
+			ctx.Log.WithFields(log.Fields{
 				"id":       preview.ID,
 				"checksum": checksum,
 			}).Debug("skip existing preview")
@@ -173,7 +173,7 @@ func (c *ascClient) UploadPreviews(ctx *context.Context, g parallel.Group, previ
 			return false, nil
 		}
 
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"name": name,
 			"id":   preview.ID,
 		}).Debug("delete preview")
@@ -186,7 +186,7 @@ func (c *ascClient) UploadPreviews(ctx *context.Context, g parallel.Group, previ
 	}
 
 	create := func(name string, size int64) (id string, ops []asc.UploadOperation, err error) {
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"name": name,
 		}).Debug("create preview")
 
@@ -201,7 +201,7 @@ func (c *ascClient) UploadPreviews(ctx *context.Context, g parallel.Group, previ
 	for i := range previewConfigs {
 		previewConfig := previewConfigs[i]
 		commit := func(id string, checksum string) error {
-			log.WithFields(log.Fields{
+			ctx.Log.WithFields(log.Fields{
 				"id": id,
 			}).Debug("commit preview")
 
@@ -277,7 +277,7 @@ func (c *ascClient) UploadScreenshots(ctx *context.Context, g parallel.Group, sc
 
 		if shot.Attributes.SourceFileChecksum != nil &&
 			*shot.Attributes.SourceFileChecksum == checksum {
-			log.WithFields(log.Fields{
+			ctx.Log.WithFields(log.Fields{
 				"id":       shot.ID,
 				"checksum": checksum,
 			}).Debug("skip existing screenshot")
@@ -285,7 +285,7 @@ func (c *ascClient) UploadScreenshots(ctx *context.Context, g parallel.Group, sc
 			return false, nil
 		}
 
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"name": name,
 			"id":   shot.ID,
 		}).Debug("delete screenshot")
@@ -298,7 +298,7 @@ func (c *ascClient) UploadScreenshots(ctx *context.Context, g parallel.Group, sc
 	}
 
 	create := func(name string, size int64) (id string, ops []asc.UploadOperation, err error) {
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"name": name,
 		}).Debug("create screenshot")
 
@@ -311,7 +311,7 @@ func (c *ascClient) UploadScreenshots(ctx *context.Context, g parallel.Group, sc
 	}
 
 	commit := func(id string, checksum string) error {
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"id": id,
 		}).Debug("commit screenshot")
 
@@ -362,7 +362,7 @@ func (c *ascClient) UploadReviewAttachments(ctx *context.Context, reviewDetailID
 
 		if attachment.Attributes.SourceFileChecksum != nil &&
 			*attachment.Attributes.SourceFileChecksum == checksum {
-			log.WithFields(log.Fields{
+			ctx.Log.WithFields(log.Fields{
 				"id":       attachment.ID,
 				"checksum": checksum,
 			}).Debug("skip existing attachment")
@@ -370,7 +370,7 @@ func (c *ascClient) UploadReviewAttachments(ctx *context.Context, reviewDetailID
 			return false, nil
 		}
 
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"name": name,
 			"id":   attachment.ID,
 		}).Debug("delete attachment")
@@ -383,7 +383,7 @@ func (c *ascClient) UploadReviewAttachments(ctx *context.Context, reviewDetailID
 	}
 
 	create := func(name string, size int64) (id string, ops []asc.UploadOperation, err error) {
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"name": name,
 		}).Debug("create attachment")
 
@@ -396,7 +396,7 @@ func (c *ascClient) UploadReviewAttachments(ctx *context.Context, reviewDetailID
 	}
 
 	commit := func(id string, checksum string) error {
-		log.WithFields(log.Fields{
+		ctx.Log.WithFields(log.Fields{
 			"id": id,
 		}).Debug("commit attachment")
 

--- a/internal/client/clienttest/clienttest_test.go
+++ b/internal/client/clienttest/clienttest_test.go
@@ -33,6 +33,7 @@ func TestClient(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	c := clienttest.Client{}
 
 	app, err := c.GetAppForBundleID(ctx, "TEST")

--- a/internal/client/store.go
+++ b/internal/client/store.go
@@ -23,7 +23,6 @@ package client
 import (
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/cidertool/asc-go/asc"
 	"github.com/cidertool/cider/internal/parallel"
 	"github.com/cidertool/cider/pkg/config"
@@ -236,11 +235,11 @@ func (c *ascClient) UpdateAppLocalizations(ctx *context.Context, appID string, c
 		for i := range appLocResp.Data {
 			loc := appLocResp.Data[i]
 			locale := *loc.Attributes.Locale
-			log.WithField("locale", locale).Debug("found app locale")
+			ctx.Log.WithField("locale", locale).Debug("found app locale")
 			locConfig, ok := config[locale]
 
 			if !ok {
-				log.WithField("locale", locale).Debug("not in configuration. skipping...")
+				ctx.Log.WithField("locale", locale).Debug("not in configuration. skipping...")
 
 				continue
 			}
@@ -339,11 +338,11 @@ func (c *ascClient) UpdateVersionLocalizations(ctx *context.Context, versionID s
 	for i := range locListResp.Data {
 		loc := locListResp.Data[i]
 		locale := *loc.Attributes.Locale
-		log.WithField("locale", locale).Debug("found version locale")
+		ctx.Log.WithField("locale", locale).Debug("found version locale")
 		locConfig, ok := config[locale]
 
 		if !ok {
-			log.WithField("locale", locale).Debug("not in configuration. skipping...")
+			ctx.Log.WithField("locale", locale).Debug("not in configuration. skipping...")
 
 			continue
 		}
@@ -351,7 +350,7 @@ func (c *ascClient) UpdateVersionLocalizations(ctx *context.Context, versionID s
 		found[locale] = true
 
 		g.Go(func() error {
-			log.WithField("locale", locale).Debug("update version locale")
+			ctx.Log.WithField("locale", locale).Debug("update version locale")
 			updatedLocResp, _, err := c.client.Apps.UpdateAppStoreVersionLocalization(ctx, loc.ID, appStoreVersionLocalizationUpdateRequestAttributes(ctx, locConfig))
 			if err != nil {
 				return err
@@ -370,7 +369,7 @@ func (c *ascClient) UpdateVersionLocalizations(ctx *context.Context, versionID s
 		locConfig := config[locale]
 
 		g.Go(func() error {
-			log.WithField("locale", locale).Debug("create version locale")
+			ctx.Log.WithField("locale", locale).Debug("create version locale")
 			locResp, _, err := c.client.Apps.CreateAppStoreVersionLocalization(ctx.Context, appStoreVersionLocalizationCreateRequestAttributes(ctx, locale, locConfig), versionID)
 			if err != nil {
 				return err

--- a/internal/client/util_test.go
+++ b/internal/client/util_test.go
@@ -31,7 +31,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/apex/log"
+	"github.com/cidertool/cider/internal/log"
 	"github.com/cidertool/cider/pkg/config"
 	"github.com/cidertool/cider/pkg/context"
 	"github.com/stretchr/testify/assert"
@@ -67,7 +67,9 @@ type testAsset struct {
 
 func newTestContext(resp ...response) (*testContext, Client) {
 	ctx := testContext{}
+
 	ctx.Context = context.New(config.Project{})
+
 	server := httptest.NewServer(&ctx)
 	ctx.Context.Credentials = &mockCredentials{
 		url:    server.URL,
@@ -86,14 +88,14 @@ func (c *testContext) Close() {
 
 func (c *testContext) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if c.CurrentResponseIndex >= len(c.Responses) {
-		log.WithFields(log.Fields{
+		c.Context.Log.WithFields(log.Fields{
 			"currentResponseIndex": c.CurrentResponseIndex,
 			"responsesCount":       len(c.Responses),
 			"url":                  r.URL,
 		}).Fatal("index out of bounds")
 	}
 
-	log.WithFields(log.Fields{
+	c.Context.Log.WithFields(log.Fields{
 		"progress":   fmt.Sprintf("(%d/%d)", c.CurrentResponseIndex, len(c.Responses)),
 		"req_method": r.Method,
 		"req_url":    r.URL,

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -54,6 +54,7 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	client := New(ctx)
 	ok := client.IsRepo()
 	assert.True(t, ok)
@@ -69,6 +70,7 @@ func TestSanitizeProcess(t *testing.T) {
 	}
 
 	ctx := context.New(config.Project{})
+
 	ctx.CurrentDirectory = "test"
 	client := newMockGitWithContext(
 		t,

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -22,6 +22,7 @@ along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 package log
 
 import (
+	"os"
 	"sync"
 
 	"github.com/apex/log"
@@ -50,7 +51,7 @@ type Log struct {
 func New() *Log {
 	return &Log{
 		Logger: log.Logger{
-			Handler: cli.Default,
+			Handler: cli.New(os.Stderr),
 			Level:   log.InfoLevel,
 		},
 	}
@@ -81,5 +82,8 @@ func (l *Log) SetPadding(v int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	cli.Default.Padding = v
+	if handler, ok := l.Handler.(*cli.Handler); ok {
+		handler.Padding = v
+		l.Handler = handler
+	}
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,74 @@
+/**
+Copyright (C) 2020 Aaron Sky.
+
+This file is part of Cider, a tool for automating submission
+of apps to Apple's App Stores.
+
+Cider is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Cider is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Cider.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Package logger is a substitute for the global apex/log that is not thread safe
+package log
+
+import (
+	"sync"
+
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/cli"
+	"github.com/fatih/color"
+)
+
+type Interface interface {
+	log.Interface
+	SetColorMode(v bool)
+	SetDebug(v bool)
+	SetPadding(v int)
+}
+
+type Fields = log.Fields
+
+type Log struct {
+	log.Logger
+	mu sync.RWMutex
+}
+
+func New() *Log {
+	return &Log{
+		Logger: log.Logger{
+			Handler: cli.Default,
+			Level:   log.InfoLevel,
+		},
+	}
+}
+
+func (l *Log) SetColorMode(v bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	color.NoColor = false
+}
+
+func (l *Log) SetDebug(v bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.Logger.Level = log.DebugLevel
+}
+
+func (l *Log) SetPadding(v int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	cli.Default.Padding = v
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License
 along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// Package logger is a substitute for the global apex/log that is not thread safe
+// Package log is a substitute for the global apex/log that is not thread safe.
 package log
 
 import (
@@ -29,6 +29,7 @@ import (
 	"github.com/fatih/color"
 )
 
+// Interface is an extension of log.Interface.
 type Interface interface {
 	log.Interface
 	SetColorMode(v bool)
@@ -36,13 +37,16 @@ type Interface interface {
 	SetPadding(v int)
 }
 
+// Fields re-exports log.Fields from github.com/apex/log.
 type Fields = log.Fields
 
+// Log is a thread-safe wrapper for log.Logger.
 type Log struct {
 	log.Logger
 	mu sync.RWMutex
 }
 
+// New creates a new Log instance.
 func New() *Log {
 	return &Log{
 		Logger: log.Logger{
@@ -52,20 +56,27 @@ func New() *Log {
 	}
 }
 
+// SetColorMode sets the global color mode for the logger.
 func (l *Log) SetColorMode(v bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	color.NoColor = false
+	color.NoColor = v
 }
 
+// SetDebug sets the log level to Debug or Info.
 func (l *Log) SetDebug(v bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.Logger.Level = log.DebugLevel
+	if v {
+		l.Logger.Level = log.DebugLevel
+	} else {
+		l.Logger.Level = log.InfoLevel
+	}
 }
 
+// SetPadding sets the padding of the log handler in a thread-safe way.
 func (l *Log) SetPadding(v int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -18,28 +18,6 @@ You should have received a copy of the GNU General Public License
 along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package middleware
+package log
 
-import (
-	"github.com/cidertool/cider/internal/pipe"
-	"github.com/cidertool/cider/pkg/context"
-)
-
-// ErrHandler handles an action error, ignoring and logging pipe skipped
-// errors.
-func ErrHandler(action Action) Action {
-	return func(ctx *context.Context) error {
-		var err = action(ctx)
-		if err == nil {
-			return nil
-		}
-
-		if pipe.IsSkip(err) {
-			ctx.Log.WithError(err).Warn("pipe skipped")
-
-			return nil
-		}
-
-		return err
-	}
-}
+// this package has no testable statements

--- a/internal/middleware/error_test.go
+++ b/internal/middleware/error_test.go
@@ -36,9 +36,11 @@ func TestErrHandler_WrapsError(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	wrapped := ErrHandler(func(ctx *context.Context) error {
 		return errTestError
 	})
+
 	err := wrapped(ctx)
 	assert.Error(t, err)
 }
@@ -47,9 +49,11 @@ func TestErrHandler_IgnoresNoError(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	wrapped := ErrHandler(func(ctx *context.Context) error {
 		return nil
 	})
+
 	err := wrapped(ctx)
 	assert.NoError(t, err)
 }
@@ -58,9 +62,11 @@ func TestErrHandler_HandlesSkip(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	wrapped := ErrHandler(func(ctx *context.Context) error {
 		return pipe.Skip("TEST")
 	})
+
 	err := wrapped(ctx)
 	assert.NoError(t, err)
 }

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -32,9 +32,11 @@ func TestLogging(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	wrapped := Logging("TEST", func(ctx *context.Context) error {
 		return nil
 	}, DefaultInitialPadding)
+
 	err := wrapped(ctx)
 	assert.NoError(t, err)
 }

--- a/internal/parallel/group_test.go
+++ b/internal/parallel/group_test.go
@@ -29,14 +29,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// nolint: gochecknoglobals
-var (
-	errTestError = errors.New("TEST")
-	groupMu      sync.Mutex
-)
+var errTestError = errors.New("TEST")
 
 func TestGroup(t *testing.T) {
 	t.Parallel()
+
+	var groupMu sync.Mutex
 
 	var g = New(4)
 

--- a/internal/pipe/defaults/defaults_test.go
+++ b/internal/pipe/defaults/defaults_test.go
@@ -36,6 +36,7 @@ func TestDefaults(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	pipe := Pipe{}
 
 	var err error

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -34,6 +34,7 @@ func TestEnv(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	pipe := Pipe{}
 
 	var err error

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apex/log"
 	"github.com/cidertool/cider/internal/git"
+	"github.com/cidertool/cider/internal/log"
 	"github.com/cidertool/cider/internal/pipe"
 	"github.com/cidertool/cider/pkg/context"
 )
@@ -76,7 +76,7 @@ func (p Pipe) Run(ctx *context.Context) error {
 
 	ctx.Git = info
 
-	log.WithFields(log.Fields{
+	ctx.Log.WithFields(log.Fields{
 		"commit": info.Commit,
 		"tag":    info.CurrentTag,
 		"date":   info.CommitDate.String(),
@@ -93,7 +93,7 @@ func (p Pipe) Run(ctx *context.Context) error {
 		ctx.Version = strings.TrimPrefix(tag, "v")
 	}
 
-	log.WithFields(log.Fields{
+	ctx.Log.WithFields(log.Fields{
 		"version": ctx.Version,
 		"commit":  info.Commit,
 		"workdir": ctx.CurrentDirectory,

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -45,7 +45,9 @@ func TestGit_Happy(t *testing.T) {
 		CommitDate:  time.Unix(1600914830, 0).UTC(),
 		URL:         "git@github.com:cidertool/cider.git",
 	}
+
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{Stdout: "true"},
@@ -70,6 +72,7 @@ func TestGit_RealGitClient(t *testing.T) {
 
 	ctx := context.New(config.Project{})
 	ctx.CurrentDirectory = "TEST"
+
 	p := Pipe{}
 	err := p.Run(ctx)
 	assert.EqualError(t, err, "the directory at TEST is not a git repository")
@@ -81,6 +84,7 @@ func TestGit_SkipGit(t *testing.T) {
 	ctx := context.New(config.Project{})
 	ctx.Version = "1.0"
 	ctx.SkipGit = true
+
 	p := Pipe{}
 
 	err := p.Run(ctx)
@@ -98,7 +102,9 @@ func TestGit_Happy_EnvCurrentTag(t *testing.T) {
 		CommitDate:  time.Unix(1600914830, 0).UTC(),
 		URL:         "git@github.com:cidertool/cider.git",
 	}
+
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{Stdout: "true"},
@@ -125,6 +131,7 @@ func TestGit_Err_NoGit(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = &git.Git{
 		Shell: &shelltest.Shell{
@@ -144,6 +151,7 @@ func TestGit_Err_NotInRepo(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{ReturnCode: 128, Stdout: "fatal"},
@@ -159,7 +167,9 @@ func TestGit_Err_BadCommit(t *testing.T) {
 	expected := context.GitInfo{
 		ShortCommit: "abcdef12",
 	}
+
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{Stdout: "true"},
@@ -184,7 +194,9 @@ func TestGit_Err_BadTime(t *testing.T) {
 		ShortCommit: "abcdef12",
 		FullCommit:  "abcdef1234567890abcdef1234567890abcdef12",
 	}
+
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{Stdout: "true"},
@@ -225,7 +237,9 @@ func TestGit_Err_BadTag(t *testing.T) {
 		CommitDate:  time.Unix(1600914830, 0).UTC(),
 		URL:         "git@github.com:cidertool/cider.git",
 	}
+
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{Stdout: "true"},
@@ -251,7 +265,9 @@ func TestGit_Err_DirtyWorkingCopy(t *testing.T) {
 		CommitDate:  time.Unix(1600914830, 0).UTC(),
 		URL:         "git@github.com:cidertool/cider.git",
 	}
+
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{Stdout: "true"},
@@ -278,7 +294,9 @@ func TestGit_Err_InvalidTag(t *testing.T) {
 		CommitDate:  time.Unix(1600914830, 0).UTC(),
 		URL:         "git@github.com:cidertool/cider.git",
 	}
+
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 	p.client = newMockGitWithContext(ctx,
 		shelltest.Command{Stdout: "true"},

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -21,7 +21,6 @@ along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 package git
 
 import (
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -89,42 +88,6 @@ func TestGit_SkipGit(t *testing.T) {
 
 	err := p.Run(ctx)
 	assert.EqualError(t, err, pipe.ErrSkipGitEnabled.Error())
-}
-
-func TestGit_Happy_EnvCurrentTag(t *testing.T) {
-	t.Parallel()
-
-	expected := context.GitInfo{
-		CurrentTag:  "1.0.0",
-		Commit:      "abcdef1234567890abcdef1234567890abcdef12",
-		ShortCommit: "abcdef12",
-		FullCommit:  "abcdef1234567890abcdef1234567890abcdef12",
-		CommitDate:  time.Unix(1600914830, 0).UTC(),
-		URL:         "git@github.com:cidertool/cider.git",
-	}
-
-	ctx := context.New(config.Project{})
-
-	p := Pipe{}
-	p.client = newMockGitWithContext(ctx,
-		shelltest.Command{Stdout: "true"},
-		shelltest.Command{Stdout: expected.ShortCommit},
-		shelltest.Command{Stdout: expected.FullCommit},
-		shelltest.Command{Stdout: strconv.FormatInt(expected.CommitDate.Unix(), 10)},
-		shelltest.Command{Stdout: expected.URL},
-		shelltest.Command{},
-		shelltest.Command{Stdout: expected.CurrentTag},
-	)
-
-	err := os.Setenv("CIDER_CURRENT_TAG", expected.CurrentTag)
-	assert.NoError(t, err)
-
-	err = p.Run(ctx)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, ctx.Git)
-
-	err = os.Unsetenv("CIDER_CURRENT_TAG")
-	assert.NoError(t, err)
 }
 
 func TestGit_Err_NoGit(t *testing.T) {

--- a/internal/pipe/publish/publish_test.go
+++ b/internal/pipe/publish/publish_test.go
@@ -46,6 +46,7 @@ func TestPublish_Happy_Testflight(t *testing.T) {
 	ctx.AppsToRelease = []string{"TEST"}
 	ctx.Credentials = &clienttest.Credentials{}
 	ctx.PublishMode = context.PublishModeTestflight
+
 	p := Pipe{}
 	p.client = &clienttest.Client{}
 
@@ -62,6 +63,7 @@ func TestPublish_Happy_Store(t *testing.T) {
 	ctx.AppsToRelease = []string{"TEST"}
 	ctx.Credentials = &clienttest.Credentials{}
 	ctx.PublishMode = context.PublishModeAppStore
+
 	p := Pipe{}
 	p.client = &clienttest.Client{}
 
@@ -73,6 +75,7 @@ func TestPublish_Happy_NoApps(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.New(config.Project{})
+
 	p := Pipe{}
 
 	err := p.Run(ctx)
@@ -84,6 +87,7 @@ func TestPublish_Err_NoPublishMode(t *testing.T) {
 
 	ctx := context.New(config.Project{})
 	ctx.AppsToRelease = []string{"TEST"}
+
 	p := Pipe{}
 
 	err := p.Run(ctx)
@@ -99,6 +103,7 @@ func TestPublish_Err_AppMismatchTestflight(t *testing.T) {
 	ctx.AppsToRelease = []string{"_TEST"}
 	ctx.Credentials = &clienttest.Credentials{}
 	ctx.PublishMode = context.PublishModeTestflight
+
 	p := Pipe{}
 	p.client = &clienttest.Client{}
 
@@ -115,6 +120,7 @@ func TestPublish_Err_AppMismatchStore(t *testing.T) {
 	ctx.AppsToRelease = []string{"_TEST"}
 	ctx.Credentials = &clienttest.Credentials{}
 	ctx.PublishMode = context.PublishModeAppStore
+
 	p := Pipe{}
 	p.client = &clienttest.Client{}
 

--- a/internal/pipe/store/store.go
+++ b/internal/pipe/store/store.go
@@ -22,9 +22,9 @@ along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 package store
 
 import (
-	"github.com/apex/log"
 	"github.com/cidertool/asc-go/asc"
 	"github.com/cidertool/cider/internal/client"
+	"github.com/cidertool/cider/internal/log"
 	"github.com/cidertool/cider/internal/pipe"
 	"github.com/cidertool/cider/pkg/config"
 	"github.com/cidertool/cider/pkg/context"
@@ -52,7 +52,7 @@ func (p *Pipe) Publish(ctx *context.Context) error {
 			return pipe.ErrMissingApp{Name: name}
 		}
 
-		log.WithField("app", name).Info("updating metadata")
+		ctx.Log.WithField("app", name).Info("updating metadata")
 
 		err := p.doRelease(ctx, app)
 		if err != nil {
@@ -86,16 +86,16 @@ func (p *Pipe) doRelease(ctx *context.Context, config config.App) error {
 		return err
 	}
 
-	log.WithFields(log.Fields{
+	ctx.Log.WithFields(log.Fields{
 		"app":     *app.Attributes.BundleID,
 		"build":   *build.Attributes.Version,
 		"version": *version.Attributes.VersionString,
 	}).Info("found resources")
 
 	if ctx.SkipUpdateMetadata {
-		log.Warn("skipping updating metdata")
+		ctx.Log.Warn("skipping updating metdata")
 	} else {
-		log.Info("updating metadata")
+		ctx.Log.Info("updating metadata")
 		if err := p.updateVersionDetails(ctx, config, app, version); err != nil {
 			return err
 		}
@@ -106,14 +106,14 @@ func (p *Pipe) doRelease(ctx *context.Context, config config.App) error {
 	}
 
 	if config.Versions.PhasedReleaseEnabled && !ctx.VersionIsInitialRelease {
-		log.Info("preparing phased release details")
+		ctx.Log.Info("preparing phased release details")
 
 		if err := p.Client.EnablePhasedRelease(ctx, version.ID); err != nil {
 			return err
 		}
 	}
 
-	log.
+	ctx.Log.
 		WithField("version", *version.Attributes.VersionString).
 		Info("submitting to app store")
 
@@ -126,26 +126,26 @@ func (p *Pipe) updateVersionDetails(ctx *context.Context, config config.App, app
 		return err
 	}
 
-	log.Info("updating app details")
+	ctx.Log.Info("updating app details")
 
 	if err := p.Client.UpdateApp(ctx, app.ID, appInfo.ID, version.ID, config); err != nil {
 		return err
 	}
 
-	log.Infof("updating %d app localizations", len(config.Localizations))
+	ctx.Log.Infof("updating %d app localizations", len(config.Localizations))
 
 	if err := p.Client.UpdateAppLocalizations(ctx, app.ID, config.Localizations); err != nil {
 		return err
 	}
 
-	log.Infof("updating %d app store version localizations", len(config.Versions.Localizations))
+	ctx.Log.Infof("updating %d app store version localizations", len(config.Versions.Localizations))
 
 	if err := p.Client.UpdateVersionLocalizations(ctx, version.ID, config.Versions.Localizations); err != nil {
 		return err
 	}
 
 	if config.Versions.IDFADeclaration != nil {
-		log.Info("updating IDFA declaration")
+		ctx.Log.Info("updating IDFA declaration")
 
 		if err := p.Client.UpdateIDFADeclaration(ctx, version.ID, *config.Versions.IDFADeclaration); err != nil {
 			return err
@@ -153,7 +153,7 @@ func (p *Pipe) updateVersionDetails(ctx *context.Context, config config.App, app
 	}
 
 	if config.Versions.RoutingCoverage != nil {
-		log.Info("uploading routing coverage asset")
+		ctx.Log.Info("uploading routing coverage asset")
 
 		if err := p.Client.UploadRoutingCoverage(ctx, version.ID, *config.Versions.RoutingCoverage); err != nil {
 			return err
@@ -161,7 +161,7 @@ func (p *Pipe) updateVersionDetails(ctx *context.Context, config config.App, app
 	}
 
 	if config.Versions.ReviewDetails != nil {
-		log.Info("updating review details")
+		ctx.Log.Info("updating review details")
 
 		if err := p.Client.UpdateReviewDetails(ctx, version.ID, *config.Versions.ReviewDetails); err != nil {
 			return err

--- a/internal/pipe/store/store_test.go
+++ b/internal/pipe/store/store_test.go
@@ -61,6 +61,7 @@ func TestStore_Happy(t *testing.T) {
 		},
 	})
 	ctx.AppsToRelease = []string{"TEST"}
+
 	p := Pipe{}
 	p.Client = &clienttest.Client{}
 
@@ -82,6 +83,7 @@ func TestStore_Happy_Skips(t *testing.T) {
 	ctx.SkipUpdatePricing = true
 	ctx.SkipUpdateMetadata = true
 	ctx.SkipSubmit = true
+
 	p := Pipe{}
 	p.Client = &clienttest.Client{}
 
@@ -94,6 +96,7 @@ func TestStore_Happy_NoApps(t *testing.T) {
 
 	ctx := context.New(config.Project{})
 	ctx.Credentials = &clienttest.Credentials{}
+
 	p := Pipe{}
 
 	err := p.Publish(ctx)

--- a/internal/pipe/testflight/testflight_test.go
+++ b/internal/pipe/testflight/testflight_test.go
@@ -54,6 +54,7 @@ func TestTestflight_Happy(t *testing.T) {
 		},
 	})
 	ctx.AppsToRelease = []string{"TEST"}
+
 	p := Pipe{}
 	p.Client = &clienttest.Client{}
 
@@ -74,6 +75,7 @@ func TestTestflight_Happy_Skips(t *testing.T) {
 	ctx.AppsToRelease = []string{"TEST"}
 	ctx.SkipUpdateMetadata = true
 	ctx.SkipSubmit = true
+
 	p := Pipe{}
 	p.Client = &clienttest.Client{}
 
@@ -86,6 +88,7 @@ func TestTestflight_Happy_NoApps(t *testing.T) {
 
 	ctx := context.New(config.Project{})
 	ctx.Credentials = &clienttest.Credentials{}
+
 	p := Pipe{}
 
 	err := p.Publish(ctx)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/alessio/shellescape"
-	"github.com/apex/log"
+	"github.com/cidertool/cider/internal/log"
 	"github.com/cidertool/cider/pkg/context"
 )
 
@@ -116,15 +116,15 @@ func escapeArgs(args []string) []string {
 
 // Exec executes a command.
 func (sh *loginShell) Exec(cmd *exec.Cmd) (proc *CompletedProcess, err error) {
-	log.WithField("args", cmd.Args).Debug(cmd.Path)
+	sh.Context.Log.WithField("args", cmd.Args).Debug(cmd.Path)
 
 	err = cmd.Run()
 	proc = newCompletedProcess(cmd)
 
 	if proc == nil {
-		log.Debugf("last process failed to complete coherently")
+		sh.Context.Log.Debugf("last process failed to complete coherently")
 	} else {
-		log.WithFields(log.Fields{
+		sh.Context.Log.WithFields(log.Fields{
 			"code":   proc.ReturnCode,
 			"stdout": strings.TrimSpace(proc.Stdout),
 			"stderr": strings.TrimSpace(proc.Stderr),

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -31,7 +31,9 @@ import (
 func TestExec(t *testing.T) {
 	t.Parallel()
 
-	sh := New(context.New(config.Project{}))
+	ctx := context.New(config.Project{})
+
+	sh := New(ctx)
 	cmd := sh.NewCommand("echo", "dogs")
 	ps, err := sh.Exec(cmd)
 	assert.NoError(t, err)
@@ -41,7 +43,9 @@ func TestExec(t *testing.T) {
 func TestExec_Error(t *testing.T) {
 	t.Parallel()
 
-	sh := New(context.New(config.Project{}))
+	ctx := context.New(config.Project{})
+
+	sh := New(ctx)
 	cmd := sh.NewCommand("exit", "1")
 	ps, err := sh.Exec(cmd)
 	assert.Error(t, err)

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -31,9 +31,7 @@ import (
 func TestExec(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.New(config.Project{})
-
-	sh := New(ctx)
+	sh := New(context.New(config.Project{}))
 	cmd := sh.NewCommand("echo", "dogs")
 	ps, err := sh.Exec(cmd)
 	assert.NoError(t, err)
@@ -43,9 +41,7 @@ func TestExec(t *testing.T) {
 func TestExec_Error(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.New(config.Project{})
-
-	sh := New(ctx)
+	sh := New(context.New(config.Project{}))
 	cmd := sh.NewCommand("exit", "1")
 	ps, err := sh.Exec(cmd)
 	assert.Error(t, err)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cidertool/cider/internal/log"
 	"github.com/cidertool/cider/pkg/config"
 )
 
@@ -61,6 +62,7 @@ type Context struct {
 	Credentials             Credentials
 	AppsToRelease           []string
 	PublishMode             PublishMode
+	Log                     log.Interface
 	MaxProcesses            int
 	SkipGit                 bool
 	SkipUpdatePricing       bool
@@ -116,6 +118,7 @@ func Wrap(ctx ctx.Context, config config.Project) *Context {
 		RawConfig:    config,
 		Env:          splitEnv(os.Environ()),
 		Date:         time.Now(),
+		Log:          log.New(),
 		MaxProcesses: 1,
 	}
 }

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -21,7 +21,6 @@ along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 package context
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -32,10 +31,8 @@ import (
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	assert.NoError(t, os.Setenv("TEST", "DOG"))
-
 	ctx := New(config.Project{})
-	assert.Equal(t, "DOG", ctx.Env["TEST"])
+	assert.Equal(t, 1, ctx.MaxProcesses)
 }
 
 func TestNewWithTimeout(t *testing.T) {

--- a/tools/licensing/main.go
+++ b/tools/licensing/main.go
@@ -49,11 +49,6 @@ You should have received a copy of the GNU General Public License
 along with Cider.  If not, see <http://www.gnu.org/licenses/>.
 */`
 
-type exitFunc func(int)
-
-// nolint:gochecknoglobals
-var exit exitFunc = os.Exit
-
 func main() {
 	var cmd = &cobra.Command{
 		Use:               "licensing",
@@ -72,7 +67,7 @@ func main() {
 
 		log.WithError(err).Error(msg)
 
-		exit(code)
+		os.Exit(code)
 	}
 }
 


### PR DESCRIPTION
Refactor logging implementation to avoid problematic use of global logger. 